### PR TITLE
Improve README and fix binary name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN cargo build \
 
 # ---------- security scanning stage ----------
 FROM aquasec/trivy:latest AS security-scan
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/mcp_memory_server /tmp/
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/blazing_art_mcp /tmp/
 RUN trivy fs --security-checks vuln --format sarif --output /tmp/trivy-report.sarif /tmp/
 
 # ---------- runtime stage ----------
@@ -48,8 +48,8 @@ FROM gcr.io/distroless/static:nonroot
 
 # Copy binary with correct permissions
 COPY --from=builder --chown=nonroot:nonroot \
-    /app/target/x86_64-unknown-linux-musl/release/mcp_memory_server \
-    /mcp_memory_server
+    /app/target/x86_64-unknown-linux-musl/release/blazing_art_mcp \
+    /blazing_art_mcp
 
 # Security labels
 LABEL \
@@ -65,10 +65,10 @@ USER nonroot:nonroot
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD ["/mcp_memory_server", "--health-check"]
+    CMD ["/blazing_art_mcp", "--health-check"]
 
 # Default to STDIO transport
-ENTRYPOINT ["/mcp_memory_server"]
+ENTRYPOINT ["/blazing_art_mcp"]
 
 # ---------- Development variant ----------
 FROM builder AS development

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ test-load: ## Run load tests (requires wrk)
 	@sleep 3
 	@echo "Running load tests..."
 	@wrk -t12 -c400 -d30s http://localhost:4000/ || echo "Install wrk for load testing"
-	@pkill -f mcp_memory_server
+   @pkill -f blazing_art_mcp
 
 # Health Checks
 health-check: ## Run health check

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@
 
 ⚡ **Blazing-fast Adaptive Radix Tree (ART) powered MCP server** delivering **microsecond-latency** structured memory access for Large Language Models. Built with Rust for **zero V8 overhead** and **predictable performance**.
 
+This server implements the [Model Context Protocol](https://github.com/modelcontextprotocol) so any MCP-compatible LLM can query structured memory over JSON-RPC.
+
 ## 🚀 Performance Characteristics
 
 | Dataset Size | Lookup P95 | Prefix Scan (100 matches) | Memory Usage |
-|-------------|------------|---------------------------|--------------||
+|-------------|------------|---------------------------|--------------|
 | 100k keys  | **8 µs**   | **35 µs**                | **12 MB**    |
 | 1M keys    | **11 µs**  | **60 µs**                | **85 MB**    |
 
@@ -39,6 +41,18 @@
 - **🔌 Model Context Protocol**: Standardized LLM integration via JSON-RPC 2.0
 - **🐳 Docker**: Static-linked, distroless containers (<10MB)
 - **☸️ Kubernetes**: Production-ready with autoscaling, monitoring, security
+
+## 🛠 Prerequisites
+
+Install **Rust 1.76+** using [rustup](https://rustup.rs/) if you don't already
+have the toolchain:
+
+```bash
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+source $HOME/.cargo/env
+```
+
+Then you can build and test the project with `cargo build` and `cargo test`.
 
 ## 🎯 Quick Start
 
@@ -95,7 +109,7 @@ curl http://localhost:3000/health/ready
 ### Command Line Options
 
 ```bash
-mcp_memory_server [OPTIONS]
+blazing_art_mcp [OPTIONS]
 
 Options:
   --entities <FILE>      JSON file with entity data to preload
@@ -308,7 +322,7 @@ docker run --rm mcp-memory:scan cat /tmp/trivy-report.sarif
 **Container fails health check:**
 ```bash
 # Check health endpoint directly
-docker exec -it <container> /mcp_memory_server --health-check
+docker exec -it <container> /blazing_art_mcp --health-check
 
 # Verify port binding
 docker ps | grep mcp-memory
@@ -325,7 +339,7 @@ curl http://localhost:3000/metrics
 **Performance degradation:**
 ```bash
 # Enable debug logging
-RUST_LOG=debug ./mcp_memory_server
+RUST_LOG=debug ./blazing_art_mcp
 
 # Check for JSON serialization bottlenecks in traces
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,13 +28,13 @@ services:
     environment:
       - RUST_LOG=info
     command: [
-      "/mcp_memory_server",
+      "/blazing_art_mcp",
       "--ws", "0.0.0.0:4000",
       "--health-port", "3000",
       "--telemetry"
     ]
     healthcheck:
-      test: ["/mcp_memory_server", "--health-check"]
+      test: ["/blazing_art_mcp", "--health-check"]
       interval: 30s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
## Summary
- document Rust prerequisites in README
- use `blazing_art_mcp` binary in Dockerfile, compose, and Makefile

## Testing
- `cargo test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687c1ada4a488326ac3c4433cfae5f16